### PR TITLE
Add Laravel 13+ Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `XgApiClient` will be documented in this file.
 
+## 6.3.0 - 2026-April-10
+
+- Added Laravel 13+ support
+- Updated PHP requirement to ^8.2 || ^8.3
+
 ## 1.0.0 - 202X-XX-XX
 
 - initial release

--- a/composer.json
+++ b/composer.json
@@ -19,16 +19,16 @@
         }
     ],
     "require": {
-        "php": "^8.1",
-        "laravel/framework": "^12.13.0",
+        "php": "^8.2 || ^8.3",
+        "laravel/framework": "^12.13.0 || ^13.4.0",
         "mews/purifier": "^3.4.3",
         "spatie/laravel-package-tools": "^1.9.2"
     },
     "require-dev": {
+        "larastan/larastan": "^3.9",
         "mockery/mockery": "^1.6",
-        "nunomaduro/collision": "^8.0",
-        "nunomaduro/larastan": "^3.4.0",
-        "orchestra/testbench": "^10.0.0",
+        "nunomaduro/collision": "^8.0 || ^9.0",
+        "orchestra/testbench": "^10.0.0 || ^11.0.0",
         "pestphp/pest": "^v3.7.3",
         "pestphp/pest-plugin-laravel": "^3.0",
         "phpstan/extension-installer": "^1.1",


### PR DESCRIPTION
- Update laravel/framework constraint to ^12.13.0 || ^13.4.0
- Update orchestra/testbench to ^10.0.0 || ^11.0.0
- Update nunomaduro/collision to ^8.0 || ^9.0
- Replace abandoned nunomaduro/larastan with larastan/larastan ^3.9
- Update PHP requirement to ^8.2 || ^8.3 (Laravel 12 requires 8.2+, Laravel 13 requires 8.3+)